### PR TITLE
#135842529 Sets players limit on game invite

### DIFF
--- a/config/socket/game.js
+++ b/config/socket/game.js
@@ -27,7 +27,7 @@ function Game(gameID, io) {
   this.winnerAutopicked = false;
   this.czar = -1; // Index in this.players
   this.playerMinLimit = 3;
-  this.playerMaxLimit = 6;
+  this.playerMaxLimit = 11;
   this.pointLimit = 5;
   this.state = "awaiting players";
   this.round = 0;

--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -12,7 +12,7 @@ angular.module('mean.system')
     table: [],
     czar: null,
     playerMinLimit: 3,
-    playerMaxLimit: 6,
+    playerMaxLimit: 11,
     pointLimit: null,
     state: null,
     round: 0,

--- a/public/views/question.html
+++ b/public/views/question.html
@@ -7,7 +7,7 @@
     <div id="startGame" ng-show="game.state === 'awaiting players'">
       <div id="finding-players">Finding Players</div>
       <div id="player-count-container">
-        <div id="player-count">{{game.players.length}} / 6 </div>
+        <div id="player-count">{{game.players.length}} / 11 </div>
         <div id="the-word-players"> Players </div>
       </div>
       <div id="loading-container">

--- a/public/views/start-game.html
+++ b/public/views/start-game.html
@@ -1,5 +1,5 @@
 <div id = "startGame" ng-click="startGame()"> 
-      <div id="player-count">{{game.players.length}} / 6 </div>
+      <div id="player-count">{{game.players.length}} / 11 </div>
       <div id="the-word-players"> Players </div> 
     </div>
     <div id="loading-container">


### PR DESCRIPTION
 #### What does this PR do?
 Enables a maximum of 11 people to join an invited game.

 #### Description of Task to be completed?
Users should be able to invite people to their game up to a maximum of 11 other people, so no game can exceed 12 people in total and must have at least 3 players.

 #### How should this be manually tested?
Run the deployed app. Sign up, click play game with friends. Send invite link to 11 friends.

 #### Any background context you want to provide?
 #### What are the relevant pivotal tracker stories?
#135842529
 #### Screenshots (if appropriate)
 #### Questions:
