### PR TITLE
#135842529 Sets players limit on invites

### DIFF
--- a/config/socket/game.js
+++ b/config/socket/game.js
@@ -27,7 +27,7 @@ function Game(gameID, io) {
   this.winnerAutopicked = false;
   this.czar = -1; // Index in this.players
   this.playerMinLimit = 3;
-  this.playerMaxLimit = 6;
+  this.playerMaxLimit = 11;
   this.pointLimit = 5;
   this.state = "awaiting players";
   this.round = 0;

--- a/config/socket/game.js
+++ b/config/socket/game.js
@@ -84,6 +84,14 @@ Game.prototype.sendNotification = function(msg) {
   this.io.sockets.in(this.gameID).emit('notification', {notification: msg});
 };
 
+// Called when a player tries to enter a game that has already started
+Game.prototype.Notification = function(playerID, msg) {
+  // sends a notification to a specific player
+  if (this.io.sockets.connected[playerID]) {
+    this.io.sockets.connected[playerID].emit('notification', {notification: msg});
+}
+};
+
 // Currently called on each joinGame event from socket.js
 // Also called on removePlayer IF game is in 'awaiting players' state
 Game.prototype.assignPlayerColors = function() {

--- a/config/socket/socket.js
+++ b/config/socket/socket.js
@@ -113,6 +113,20 @@ module.exports = function(io) {
     if (requestedGameId.length && allGames[requestedGameId]) {
       console.log('Room',requestedGameId,'is valid');
       var game = allGames[requestedGameId];
+
+      
+      if (game.state === 'waiting for players to pick') {
+        playerID = player.socket.id;
+        // Alerts players trying to access an already full game
+        if (game.players.length === game.playerMaxLimit) {
+          game.Notification(playerID, 'Hey full house, get lost');
+        } 
+        // Alerts players trying to request an already started game 
+        else {
+          game.Notification(playerID, 'Game has already started');
+        }
+      }
+
       // Ensure that the same socket doesn't try to join the same game
       // This can happen because we rewrite the browser's URL to reflect
       // the new game ID, causing the view to reload.

--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -12,7 +12,7 @@ angular.module('mean.system')
     table: [],
     czar: null,
     playerMinLimit: 3,
-    playerMaxLimit: 6,
+    playerMaxLimit: 11,
     pointLimit: null,
     state: null,
     round: 0,

--- a/public/views/question.html
+++ b/public/views/question.html
@@ -7,7 +7,7 @@
     <div id="startGame" ng-show="game.state === 'awaiting players'">
       <div id="finding-players">Finding Players</div>
       <div id="player-count-container">
-        <div id="player-count">{{game.players.length}} / 6 </div>
+        <div id="player-count">{{game.players.length}} / 11 </div>
         <div id="the-word-players"> Players </div>
       </div>
       <div id="loading-container">

--- a/public/views/question.html
+++ b/public/views/question.html
@@ -13,6 +13,9 @@
       <div id="loading-container">
         <div id="loading-gif"><img ng-src="../img/loader.gif"/></div>
       </div>
+      <div id="min-player-container" ng-show="(game.joinOverride) && game.players.length < game.playerMinLimit">
+          Cannot start game with less than 3 people
+      </div>
       <div id="start-game-container" ng-click="startGame()" ng-show="(game.playerIndex === 0 || game.joinOverride) && game.players.length >= game.playerMinLimit">
         <div id='start-game-button'>
           Start Game</br>with {{game.players.length}} players

--- a/public/views/start-game.html
+++ b/public/views/start-game.html
@@ -1,5 +1,5 @@
 <div id = "startGame" ng-click="startGame()"> 
-      <div id="player-count">{{game.players.length}} / 6 </div>
+      <div id="player-count">{{game.players.length}} / 11 </div>
       <div id="the-word-players"> Players </div> 
     </div>
     <div id="loading-container">


### PR DESCRIPTION
 #### What does this PR do?
Sets the maximum and minimum players in an invited game.

 #### Description of Task to be completed?
Sets the minimum number of players in a game to 3 and maximum to 12. Sends a notification to a player trying to join a full game. Alerts players in a game with less than 3 people that the minimum number of players is 3.

 #### How should this be manually tested?
Open the deployed version, sign up, click 'Play Game with Friends', send invite link or copy invite link to another browser.

Game with less than 3 people: open the invite link once and wait.
Game with more than 12 people: open the invite link more than 11 times.
Joining an already started game: open invite link more than 3 times, click start game, open invite link after game has started.

 #### What are the relevant pivotal tracker stories?
#135842529
