### PR TITLE
#135842515 add npm install to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: node_js
 node_js:
   - "6"
+before_install:  
+  - npm install -g npm
 before_script:
-  - npm install
   - npm install -g gulp
-script: 
-  - gulp
 after_script:
   - npm run coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: node_js
 node_js:
   - "6"
+before_script:
+  - npm install
+  - npm install -g gulp
+script: 
+  - gulp
 after_script:
   - npm run coverage
+


### PR DESCRIPTION
 #### What does this PR do?
Adds npm install to travis.yml

 #### Description of Task to be completed?
Ensures travis `npm install gulp` before scripts to enable travis to run gulp.

 #### How should this be manually tested?
Click on the travis badge.

 #### Any background context you want to provide?
Travis CI uses npm version 1.4. To avoid any obscure errors in the future, `npm install -g npm` has been added before any install.

 #### What are the relevant pivotal tracker stories?
#135842515